### PR TITLE
Document our code of conduct for GitHub

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,6 @@
+# Code of conduct
+
+By participating in this project, you agree to abide by the
+[thoughtbot code of conduct][1].
+
+[1]: https://thoughtbot.com/open-source-code-of-conduct


### PR DESCRIPTION
GitHub expects to find the code of conduct in the file named
`CODE_OF_CONDUCT.md`, so put a link in there to our official code of
conduct.

This shows on the community page: https://github.com/thoughtbot/monocats/community